### PR TITLE
fix(docker): add git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN ./bin/build github-changelog.jar
 
 FROM openjdk:jre-alpine
 
+RUN apk --no-cache add git
+
 WORKDIR /usr/local/github-changelog
 
 COPY --from=builder /usr/local/github-changelog/github-changelog.jar .


### PR DESCRIPTION
The `git` command is missing from the Docker image, so for example, if one wants to generate the change log for this repository, the following will happen:

```console
$ cat github-changelog.config.edn | docker run -i --rm whitepages/github-changelog -
Execution error (IOException) at java.lang.UNIXProcess/forkAndExec (UNIXProcess.java:-2).
error=2, No such file or directory
Full report at:
/tmp/clojure-636786992830612712.edn
$ cat github-changelog.config.edn
{
 :github "https://github.com/"
 :github-api "https://api.github.com/"
 :user "whitepages"
 :repo "github-changelog"
 :token $YOUR_OAUTH_TOKEN
 :update true?
}
```
