### PR TITLE
feat(github): make the use of OAuth tokens optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Here is an example usage:
 |---------------|------------------------------------------------------------------|----------|
 | `:user`       | Username for the repo                                            | ✓        |
 | `:repo`       | Repository name                                                  | ✓        |
-| `:token`      | GitHub [access token] to reach the API                           | ✓        |
+| `:token`      | GitHub [access token] to reach the API                           | ✗        |
 | `:github`     | GitHub URL                                                       | ✗        |
 | `:github-api` | URL for [GitHub Enterprise API]                                  | ✗        |
 | `:jira`       | JIRA URL if you're using that for issue tracking                 | ✗        |

--- a/src/github_changelog/github.clj
+++ b/src/github_changelog/github.clj
@@ -15,16 +15,16 @@
                   :or   {github-api (:github-api defaults/config)}}]
   (format "%s/repos/%s/%s/pulls" (util/strip-trailing github-api) user repo))
 
-(defn- auth-headers [token]
-  {"User-Agent"    "GitHub-Changelog"
-   "Authorization" (str "token " token)})
+(defn- headers [token]
+  (cond-> {"User-Agent" "GitHub-Changelog"}
+    token (assoc "Authorization" (str "token " token))))
 
 (defn- make-request
   ([config] (make-request config {}))
   ([{oauth-token :token} params]
-   (cond-> {:as           :json
-            :query-params (merge {:state "closed"} params)}
-     oauth-token (assoc :headers (auth-headers oauth-token)))))
+   {:as           :json
+    :query-params (merge {:state "closed"} params)
+    :headers      (headers oauth-token)}))
 
 (defn- last-page-number [links]
   (some-> (get-in links [:last :href])

--- a/src/github_changelog/github.clj
+++ b/src/github_changelog/github.clj
@@ -15,13 +15,16 @@
                   :or   {github-api (:github-api defaults/config)}}]
   (format "%s/repos/%s/%s/pulls" (util/strip-trailing github-api) user repo))
 
+(defn- auth-headers [token]
+  {"User-Agent"    "GitHub-Changelog"
+   "Authorization" (str "token " token)})
+
 (defn- make-request
   ([config] (make-request config {}))
   ([{oauth-token :token} params]
-   {:as           :json
-    :query-params (merge {:state "closed"} params)
-    :headers      {"User-Agent"    "GitHub-Changelog"
-                   "Authorization" (str "token " oauth-token)}}))
+   (cond-> {:as           :json
+            :query-params (merge {:state "closed"} params)}
+     oauth-token (assoc :headers (auth-headers oauth-token)))))
 
 (defn- last-page-number [links]
   (some-> (get-in links [:last :href])

--- a/src/github_changelog/github.clj
+++ b/src/github_changelog/github.clj
@@ -15,11 +15,11 @@
                   :or   {github-api (:github-api defaults/config)}}]
   (format "%s/repos/%s/%s/pulls" (util/strip-trailing github-api) user repo))
 
-(defn- headers [token]
+(defn headers [token]
   (cond-> {"User-Agent" "GitHub-Changelog"}
     token (assoc "Authorization" (str "token " token))))
 
-(defn- make-request
+(defn make-request
   ([config] (make-request config {}))
   ([{oauth-token :token} params]
    {:as           :json

--- a/test/github_changelog/github_test.clj
+++ b/test/github_changelog/github_test.clj
@@ -34,14 +34,14 @@
                            :state  "closed"}
             :headers      {"User-Agent"    "GitHub-Changelog"
                            "Authorization" "token abcdef"}}
-           (#'sut/make-request {:token "abcdef"} {:param1 ::value1 :param2 ::value2}))))
+           (sut/make-request {:token "abcdef"} {:param1 ::value1 :param2 ::value2}))))
   (testing "without token"
     (is (= {:as           :json
             :query-params {:param1 ::value1
                            :param2 ::value2
                            :state  "closed"}
             :headers      {"User-Agent" "GitHub-Changelog"}}
-           (#'sut/make-request {} {:param1 ::value1 :param2 ::value2})))))
+           (sut/make-request {} {:param1 ::value1 :param2 ::value2})))))
 
 (deftest parse-pull
   (let [sha (gen/generate sgen/sha)

--- a/test/github_changelog/github_test.clj
+++ b/test/github_changelog/github_test.clj
@@ -26,6 +26,22 @@
     (let [alter-config (merge config {:github-api "http://enterprise.example.com/api/v3/"})]
       (is (= "http://enterprise.example.com/api/v3/repos/raszi/changelog-test/pulls" (sut/pulls-url alter-config))))))
 
+(deftest make-request
+  (testing "with token"
+    (is (= {:as           :json
+            :query-params {:param1 ::value1
+                           :param2 ::value2
+                           :state  "closed"}
+            :headers      {"User-Agent"    "GitHub-Changelog"
+                           "Authorization" "token abcdef"}}
+           (#'sut/make-request {:token "abcdef"} {:param1 ::value1 :param2 ::value2}))))
+  (testing "without token"
+    (is (= {:as :json
+            :query-params {:param1 ::value1
+                           :param2 ::value2
+                           :state  "closed"}}
+           (#'sut/make-request {} {:param1 ::value1 :param2 ::value2})))))
+
 (deftest parse-pull
   (let [sha (gen/generate sgen/sha)
         pull (sut/parse-pull (sample-pull sha))]

--- a/test/github_changelog/github_test.clj
+++ b/test/github_changelog/github_test.clj
@@ -36,10 +36,11 @@
                            "Authorization" "token abcdef"}}
            (#'sut/make-request {:token "abcdef"} {:param1 ::value1 :param2 ::value2}))))
   (testing "without token"
-    (is (= {:as :json
+    (is (= {:as           :json
             :query-params {:param1 ::value1
                            :param2 ::value2
-                           :state  "closed"}}
+                           :state  "closed"}
+            :headers      {"User-Agent" "GitHub-Changelog"}}
            (#'sut/make-request {} {:param1 ::value1 :param2 ::value2})))))
 
 (deftest parse-pull


### PR DESCRIPTION
For publicly accessible repositories, there is no need for GitHub OAuth authentication, so no token is necessary in the configuration.

For example:

```console
$ docker run --rm -ti appropriate/curl /bin/sh
# curl -s https://api.github.com/repos/whitepages/github-changelog | head -10
{
  "id": 44343377,
  "node_id": "MDEwOlJlcG9zaXRvcnk0NDM0MzM3Nw==",
  "name": "github-changelog",
  "full_name": "whitepages/github-changelog",
  "private": false,
  "owner": {
    "login": "whitepages",
    "id": 492519,
    "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ5MjUxOQ==",
```
