### PR TITLE
fix: fetch pull request metainformation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths   ["src"]
- :deps    {org.clojure/clojure             {:mvn/version "1.10.1"}
-           org.martinklepsch/clj-http-lite {:mvn/version "0.4.1"}
-           metosin/jsonista                {:mvn/version "0.2.4"}
-           org.clojure/core.async          {:mvn/version "0.4.500"} ; clojure spec fixed
-           throttler                       {:mvn/version "1.0.0"}
-           org.slf4j/slf4j-nop             {:mvn/version "1.7.28"}
-           grimradical/clj-semver          {:mvn/version "0.3.0"
-                                            :exclusions  [org.clojure/clojure]}
-           org.clojure/tools.cli           {:mvn/version "0.4.2"}}
+ :deps    {org.clojure/clojure    {:mvn/version "1.10.1"}
+           clj-http               {:mvn/version "3.10.0"}
+           metosin/jsonista       {:mvn/version "0.2.4"}
+           org.clojure/core.async {:mvn/version "0.4.500"} ; clojure spec fixed
+           throttler              {:mvn/version "1.0.0"}
+           org.slf4j/slf4j-nop    {:mvn/version "1.7.28"}
+           grimradical/clj-semver {:mvn/version "0.3.0"
+                                   :exclusions  [org.clojure/clojure]}
+           org.clojure/tools.cli  {:mvn/version "0.4.2"}}
  :aliases {:test     {:extra-paths ["test"]
                       :extra-deps  {org.clojure/test.check        {:mvn/version "0.9.0"}
                                     lambdaisland/kaocha           {:mvn/version "0.0-541"}

--- a/src/github_changelog/github.clj
+++ b/src/github_changelog/github.clj
@@ -1,5 +1,5 @@
 (ns github-changelog.github
-  (:require [clj-http.lite.client :as http]
+  (:require [clj-http.client :as http]
             [clojure.string :as str]
             [github-changelog
              [defaults :as defaults]
@@ -22,8 +22,7 @@
 (defn make-request
   ([config] (make-request config {}))
   ([{oauth-token :token} params]
-   {:as           :json
-    :query-params (merge {:state "closed"} params)
+   {:query-params (merge {:state "closed"} params)
     :headers      (headers oauth-token)}))
 
 (defn- last-page-number [links]

--- a/test/github_changelog/github_test.clj
+++ b/test/github_changelog/github_test.clj
@@ -9,7 +9,7 @@
 
 (deftest http-get
   (is (= {:href "https://api.github.com/gists?page=2"}
-         (get-in (http/get "https://api.github.com/gists") [:links :next]))))
+         (get-in (http/get "http://www.mocky.io/v2/5dd82f43310000b77b055dbc") [:links :next]))))
 
 (def config (sgen/complete-config {:user "raszi"
                                    :repo "changelog-test"}))

--- a/test/github_changelog/github_test.clj
+++ b/test/github_changelog/github_test.clj
@@ -1,11 +1,15 @@
 (ns github-changelog.github-test
-  (:require [clj-http.lite.client :as http]
+  (:require [clj-http.client :as http]
             [clojure.test :refer :all]
             [clojure.test.check.generators :as gen]
             [github-changelog
              [github :as sut]
              [schema-generators :as sgen]]
             [jsonista.core :as j]))
+
+(deftest http-get
+  (is (= {:href "https://api.github.com/gists?page=2"}
+         (get-in (http/get "https://api.github.com/gists") [:links :next]))))
 
 (def config (sgen/complete-config {:user "raszi"
                                    :repo "changelog-test"}))
@@ -28,16 +32,14 @@
 
 (deftest make-request
   (testing "with token"
-    (is (= {:as           :json
-            :query-params {:param1 ::value1
+    (is (= {:query-params {:param1 ::value1
                            :param2 ::value2
                            :state  "closed"}
             :headers      {"User-Agent"    "GitHub-Changelog"
                            "Authorization" "token abcdef"}}
            (sut/make-request {:token "abcdef"} {:param1 ::value1 :param2 ::value2}))))
   (testing "without token"
-    (is (= {:as           :json
-            :query-params {:param1 ::value1
+    (is (= {:query-params {:param1 ::value1
                            :param2 ::value2
                            :state  "closed"}
             :headers      {"User-Agent" "GitHub-Changelog"}}


### PR DESCRIPTION
The functionality for parsing `Link` headers is missing from [`clj-http-lite`](https://github.com/martinklepsch/clj-http-lite), so the application will not be able to read all the pages correctly.  As a consequence, if pull requests span over multiple pages on the API, only the first page of them will be read and added to the changelog.

