### PR TITLE
chore: upgrade to clj-http-lite 0.4.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,6 @@
 {:paths   ["src"]
  :deps    {org.clojure/clojure             {:mvn/version "1.10.1"}
-           org.martinklepsch/clj-http-lite {:git/url "https://github.com/imrekoszo/clj-http-lite"
-                                            :sha "4f0ffb121837dfbceb2ac71e43d663459b7a1b22"}
+           org.martinklepsch/clj-http-lite {:mvn/version "0.4.3"}
            metosin/jsonista                {:mvn/version "0.2.4"}
            org.clojure/core.async          {:mvn/version "0.4.500"} ; clojure spec fixed
            throttler                       {:mvn/version "1.0.0"}


### PR DESCRIPTION
As https://github.com/martinklepsch/clj-http-lite/pull/1 has been merged and released there is no need for this project to depend on a fork of the library.