### PR TITLE
fix(git): pick the first one if there are multiple initial commits present

### DIFF
--- a/src/github_changelog/git.clj
+++ b/src/github_changelog/git.clj
@@ -68,7 +68,9 @@
 (defn initial-commit [dir]
   (-> (exec "git" "rev-list" "--max-parents=0" "HEAD" :dir dir)
       (:out)
-      (str/trim)))
+      (str/trim)
+      (split-lines)
+      (first)))
 
 (defn commits [dir from until]
   (let [commit (format "%s..%s"

--- a/test/github_changelog/git_helper.clj
+++ b/test/github_changelog/git_helper.clj
@@ -26,3 +26,10 @@
   ([repo tag]
    (shell/sh "git" "tag" tag :dir repo)
    tag))
+
+(defn merge-orphan-branch [repo]
+  (let [branch "orphan"]
+    (shell/sh "git" "checkout" "--orphan" branch :dir repo)
+    (add-file repo)
+    (shell/sh "git" "checkout" "master" :dir repo)
+    (shell/sh "git" "merge" "--allow-unrelated-histories" branch :dir repo)))

--- a/test/github_changelog/git_test.clj
+++ b/test/github_changelog/git_test.clj
@@ -85,6 +85,22 @@
       (finally
         (fs/rm-dir repo)))))
 
+(deftest initial-commit
+  (let [single-initial-commit? #(= 40 (count (sut/initial-commit %)))]
+    (testing "single initial commit"
+      (let [[repo] (gh/init-repo)]
+        (try
+          (is (single-initial-commit? repo))
+        (finally
+          (fs/rm-dir repo)))))
+    (testing "multiple initial commits present in the repository"
+      (let [[repo] (gh/init-repo)]
+        (try
+          (gh/merge-orphan-branch repo)
+          (is (single-initial-commit? repo))
+        (finally
+          (fs/rm-dir repo)))))))
+
 (deftest commits
   (let [[repo]    (gh/init-repo)
         commit-fn #(count (sut/commits repo nil nil))]


### PR DESCRIPTION
The logic implemented in the tool assumes that there can be only a single initial commit.  So, in cases, where unrelated histories (via orphan branches) have been merged together during the lifetime of the repository, it will fail.

The possibility of having multiple initial commits is a [known "feature" of git](https://www.destroyallsoftware.com/blog/2017/the-biggest-and-weirdest-commits-in-linux-kernel-git-history), although these days it is not preferred, [`git` will only be willing to merge unrelated histories when forced](https://github.com/git/git/blob/master/Documentation/RelNotes/2.9.0.txt#L58-L68).  Independently of this, there may be repositories laying around that have this property, and the tool should not choke on it.

The proposed solution here is to pick the first commit if multiple initial ones are present, as a heuristic.